### PR TITLE
Update GET_STARTED.md with Ubuntu installation steps

### DIFF
--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -21,3 +21,14 @@ reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" /v Allow
 ```
 
 After that a restart may be reqired.
+
+## Install Fuse for Ubuntu
+
+`libfuse2` is required on Ubuntu.
+
+```sh
+sudo apt install libfuse2
+```
+
+After that a restart may be reqired.
+


### PR DESCRIPTION
Added instructions for installing libfuse2 on Ubuntu.

```sh
$ ./Qopy-0.3.3.AppImage
dlopen(): error loading libfuse.so.2

AppImages require FUSE to run. 
You might still be able to extract the contents of this AppImage 
if you run it with the --appimage-extract option. 
See https://github.com/AppImage/AppImageKit/wiki/FUSE 
for more information
```

`libfuse2` is required and can be installed via the below:

```sh
sudo apt install libfuse2
```
